### PR TITLE
Fixed 'getAsync' to work on Android

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 // Based on this ol' library https://github.com/jgkim/react-native-status-bar-size
 // This lib is in response to this inquiry: https://forums.expo.io/t/incoming-call-phone-or-skype-or-a-connection-sharing-when-the-app-is-loaded/7086/5
-import { NativeEventEmitter, NativeModules } from 'react-native';
+import { NativeEventEmitter, NativeModules, StatusBar } from 'react-native';
 
 const { StatusBarManager } = NativeModules;
 
@@ -32,10 +32,16 @@ class StatusBarHeight {
 
   getAsync = () =>
     new Promise((res, rej) =>
-      StatusBarManager.getHeight(({ height }) => {
-        this.height = height;
-        res(height);
-      }),
+      if (StatusBarManager && StatusBarManager.getHeight) {
+        StatusBarManager.getHeight(({ height }) => {
+          this.height = height;
+          res(height);
+        }),
+      } else {
+        // on Android we can get the status bar height as a property
+        this.height = StatusBar.currentHeight;
+        res(this.height);
+      }
     );
 
   getHandlers = type => {


### PR DESCRIPTION
It was crashing with a `"getHeight" not defined` error. Turns out you can access the status bar height in Android by using the currentHeight property, so I made that change in the getAsync() method. Not sure how this impacts the event listeners.