### PR TITLE
Fix syntax errors after recent PR

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,18 +31,18 @@ class StatusBarHeight {
   }
 
   getAsync = () =>
-    new Promise((res, rej) =>
+    new Promise((res, rej) => {
       if (StatusBarManager && StatusBarManager.getHeight) {
-        StatusBarManager.getHeight(({ height }) => {
+        return StatusBarManager.getHeight(({ height }) => {
           this.height = height;
           res(height);
-        }),
+        });
       } else {
         // on Android we can get the status bar height as a property
         this.height = StatusBar.currentHeight;
         res(this.height);
       }
-    );
+    });
 
   getHandlers = type => {
     if (!this.handlers[type]) {


### PR DESCRIPTION
The promise used to implicitly return another promise. Now it has an `if` statement that can't be returned. This PR simply fixes the syntax errors so this lib can be used on Android again.

Tested and verified on Android and iOS.